### PR TITLE
Added support for *.cer *.crt *.crl to c_rehash

### DIFF
--- a/openssl-c_rehash.sh
+++ b/openssl-c_rehash.sh
@@ -140,7 +140,7 @@ hash_dir()
         fi
     done
 
-    ls -1 *.pem 2>/dev/null | while read FILE
+    ls -1 *.pem *.cer *.crt *.crl 2>/dev/null | while read FILE
     do
 	check_file ${FILE}
         local FILE_TYPE=${?}


### PR DESCRIPTION
This is aimed to keep the functionality in sync with OpenSSL 1.0.2

See https://www.openssl.org/docs/man1.0.2/apps/c_rehash.html
