### PR TITLE
openssl-ssl-certificate.sh: fix test POSIX compatibility

### DIFF
--- a/openssl-ssl-certificate.sh
+++ b/openssl-ssl-certificate.sh
@@ -8,7 +8,7 @@ if [ "$1" != "--force" -a -f $CERT ]; then
   exit 0
 fi
 
-if [ "$1" == "--force" ]; then
+if [ "$1" = "--force" ]; then
   shift
 fi     
 


### PR DESCRIPTION
The == operator is not in POSIX and will fail with some shells.
